### PR TITLE
Add devcontainer/lint tooling and sync shared instructions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/base
+{
+    "name": "GitHub Action",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/base:trixie",
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+        "ghcr.io/devcontainers-extra/features/pre-commit:2": {},
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+        "ghcr.io/devcontainers/features/github-cli:1": {},
+        "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {
+            "jqVersion": "latest",
+            "yqVersion": "latest"
+        }
+    },
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [5000, 5001],
+    // "portsAttributes": {
+    //		"5001": {
+    //			"protocol": "https"
+    //		}
+    // }
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "sh ./.devcontainer/postCreateCommand.sh",
+    "postStartCommand": "sh ./.devcontainer/postStartCommand.sh",
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Set *default* container specific settings.json values on container create.
+            "settings": {},
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": [
+                "ms-vscode.powershell",
+                "ms-azuretools.vscode-docker",
+                "ms-vscode-remote.vscode-remote-extensionpack",
+                "mutantdino.resourcemonitor",
+                "usernamehw.errorlens",
+                "davidanson.vscode-markdownlint",
+                "github.vscode-github-actions"
+            ]
+        }
+    },
+    "mounts": [
+        "source=${localEnv:HOME}${localEnv:USERPROFILE}/source/github,target=/workspaces,type=bind,consistency=cached",
+        "source=${env:HOME}${env:USERPROFILE}/.kube,target=/home/vscode/.kube,type=bind,consistency=cached"
+    ]
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,11 @@
     // Features to add to the dev container. More info: https://containers.dev/features.
     "features": {
         "ghcr.io/devcontainers-extra/features/pre-commit:2": {},
-        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+        //moby must be false on Debian trixie - the feature hard-fails because moby-cli is
+        //not published for it. Installs Docker CE CLI instead.
+        "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+            "moby": false
+        },
         "ghcr.io/devcontainers/features/github-cli:1": {},
         "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {
             "jqVersion": "latest",

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+echo "postCreateCommand.sh"
+echo "--------------------"
+
+sudo apt-get update
+sudo apt-get upgrade -y
+
+sudo chmod +x .devcontainer/postStartCommand.sh

--- a/.devcontainer/postStartCommand.sh
+++ b/.devcontainer/postStartCommand.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+echo "postStartCommand.sh"
+echo "-------------------"
+
+pre-commit autoupdate
+
+echo "Done"

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,6 +14,7 @@ Detailed conventions live in scoped instruction files under `.github/instruction
 | File | Applies to | Covers |
 | --- | --- | --- |
 | `github-actions.instructions.md` | workflows / `action.yml` | GitHub Actions naming, YAML, security, GitVersion |
+| `bash.instructions.md` | `**/*.sh` | Bash scripting structure, error handling, logging, testability |
 | `documentation.instructions.md` | `**/*.md` | README consistency & Mermaid diagrams |
 
 The conventions below always apply, regardless of the file being edited.

--- a/.github/instructions/bash.instructions.md
+++ b/.github/instructions/bash.instructions.md
@@ -1,0 +1,53 @@
+---
+description: 'Bash scripting conventions — structure, error handling, logging and testability.'
+applyTo: '**/*.sh'
+---
+
+# Bash / Shell Scripts
+
+## Structure
+
+- **Shebang**: `#!/usr/bin/env bash` (not `#!/bin/bash`) — resolves bash via `PATH` rather than assuming it lives at `/bin/bash`.
+- **Header comment**: Every script opens with a short comment block stating what it does and, when it's invoked from a GitHub Actions composite step, a `# Required environment variables: X, Y, Z` line (plus a note on which are optional). This is the script's contract — a reader shouldn't need to open the calling `action.yml` to know what it needs.
+- **Location**: Non-trivial or GitHub Actions composite-action scripts live in a dot-prefixed `.scripts/` folder at the repository (or action) root, per `github-actions.instructions.md`.
+- **Executable bit**: Set `chmod +x` on any script invoked directly by path (e.g. `run: "${{ github.action_path }}/.scripts/name.sh"`) rather than via `bash script.sh`. **Gotcha**: this container's `git config core.fileMode` is `false`, so `git add` on a newly created file does not pick up a `chmod +x` applied before staging. Verify with `git ls-files -s path/to/script.sh` shows `100755`; if it shows `100644`, fix it with `git update-index --chmod=+x path/to/script.sh` before committing.
+- **Exemption — manual/interactive runbooks**: A script meant to be read and run step-by-step by a human (contains `sudo reboot`, `sudo nano`, or similar interactive/destructive steps) is exempt from the automation conventions below. Mark it as such in its header comment (e.g. `# Run manually, step by step — not intended for unattended execution.`) so it isn't mistaken for broken automation.
+
+## Error Handling
+
+- **Validate required environment variables before enabling strict mode**, so a missing variable produces one clear, intentional error instead of bash's raw "unbound variable" trace:
+
+  ```bash
+  # Validate required environment variables before enabling strict mode
+  for var in FOO BAR BAZ; do
+    if [[ -z "${!var:-}" ]]; then
+      echo "::error::Required environment variable $var is not set."
+      exit 1
+    fi
+  done
+
+  set -euo pipefail
+  ```
+
+- **`set -euo pipefail`** is required in every automation script (exit on error, exit on unset variable, fail a pipeline on any stage's non-zero exit), placed immediately after the required-variable validation loop above.
+- **Default optional variables explicitly** before `set -u` takes effect, using `: "${VAR:=}"` (or a per-use `"${VAR:-}"`), so referencing an optional, legitimately-unset variable doesn't crash the script.
+- **Quote every variable expansion** (`"$var"`, `"${arr[@]}"`) unless intentional word-splitting/globbing is required — this includes file paths, which may contain spaces.
+- **Fail fast with a specific message** rather than letting an empty/invalid value propagate into a downstream command's cryptic error (e.g. validate chart registry credentials before calling `helm pull`, not after it fails).
+
+## Logging & GitHub Actions Annotations
+
+- Use `::error::message` (or `::error file=$FILE::message` when a specific file is implicated) for failures, `::warning title=X::message` for non-fatal issues, and `::add-mask::$value` for any secret obtained or derived *at runtime* (an exchanged token, a short-lived API key) — not just secrets passed in as inputs.
+- Log plain progress/diagnostic lines with `echo`; prefer one `echo` per line over `printf "\n...` continuation chains for readability of the raw log.
+- Never `echo`/log a secret value in full — redact it (e.g. `echo "CHART_REGISTRY_PASSWORD=***"`) or rely on `::add-mask::`.
+
+## Testability
+
+- **A script extracted per `github-actions.instructions.md`'s Composite Actions guidance must be runnable and testable standalone**, without a live Actions run. Depend only on the documented environment variables — nothing implicit from the Actions runtime beyond `GITHUB_ENV`/`GITHUB_OUTPUT` (which can be pointed at a temp file locally).
+- **Mock external commands** (`curl`, `helm`, `git`, cloud CLIs) for local testing by placing a stub executable earlier on `PATH` rather than hitting real endpoints or requiring live credentials. Exercise the success path and every distinct error path (missing required variable, empty/invalid response, etc.).
+- Run `shellcheck` against new or modified scripts before committing; treat anything above informational severity as worth fixing (an informational `SC2016` on an intentionally single-quoted `yq`/`jq` expression, for example, is expected and can be left as-is).
+
+## Style
+
+- **`local`** every function-scoped variable.
+- Lowercase values that feed case-sensitive downstream systems expecting lowercase (OCI registries/repositories) with `${var,,}`.
+- Clean up any temporary file/directory a script creates, even when it runs in a loop (each iteration's temp artifacts must not leak into the next).

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -64,7 +64,8 @@ applyTo: '.github/workflows/**,.github/actions/**,**/action.yml,**/action.yaml'
 ## Composite Actions
 
 - Declare `shell: bash` explicitly on every `run` step — composite actions do not inherit a default shell.
-- Reference scripts relative to the action root using `${{ github.action_path }}/scripts/name.sh`.
+- Reference scripts relative to the action root using `${{ github.action_path }}/.scripts/name.sh`.
+- **Extract sizeable or critical `run` logic into an external script** under `.scripts/` (e.g. `.scripts/check-release-exists.sh`, `.scripts/Invoke-CheckReleaseExists.ps1`) rather than inlining it in the composite action YAML. An external script can be run and tested standalone — locally or from a `.github/workflows/test.yml` — before it's ever exercised by a real Actions run; a `run: |` block embedded in YAML cannot be. Keep genuinely trivial one-liners inline.
 
 ## Security
 

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -24,6 +24,20 @@ applyTo: '.github/workflows/**,.github/actions/**,**/action.yml,**/action.yaml'
 - **Environment variables**: ALL_UPPERCASE with underscores (e.g. `IMAGE_REGISTRY`, `TAG_OVERRIDE`, `MANIFEST_PATHS`).
 - **Secrets**: ALL_UPPERCASE with underscores (e.g. `GITHUB_TOKEN`, `GH_PAT_GITOPS`, `NUGET_API_KEY`).
 
+## Descriptions
+
+- **Keep every `description:` to one short line.** It states what the value *is*, not how or why to use it. Prefer `e.g. <example>` over prose describing the format.
+- **Move rationale, caveats, deprecation notices and cross-references into a `#` comment directly above the input**, not into the description string. Use the repo's `#no-space-after-hash` comment style.
+- Avoid multi-sentence descriptions — they bloat the file and make the input list hard to scan.
+- Keeping `key: value` pairs out of descriptions also avoids the colon-space sequence that would otherwise force the whole scalar to be quoted.
+
+  ```yaml
+  #DEPRECATED, superseded by nuget-user (Trusted Publishing). Ignored when nuget-user is set.
+  NUGET_API_KEY:
+    description: Long-lived NuGet API key e.g. secrets.NUGET_API_KEY
+    type: string
+  ```
+
 ## YAML Style
 
 - **2-space indentation** for all workflow and action YAML files.

--- a/.github/instructions/github-actions.instructions.md
+++ b/.github/instructions/github-actions.instructions.md
@@ -27,6 +27,7 @@ applyTo: '.github/workflows/**,.github/actions/**,**/action.yml,**/action.yaml'
 ## Descriptions
 
 - **Keep every `description:` to one short line.** It states what the value *is*, not how or why to use it. Prefer `e.g. <example>` over prose describing the format.
+- **Applies to workflow inputs (`workflow_dispatch`, `workflow_call`) as well as action inputs.** `workflow_dispatch` descriptions render as field labels in the *Run workflow* dialog, where a long sentence wraps and makes the form look messy.
 - **Move rationale, caveats, deprecation notices and cross-references into a `#` comment directly above the input**, not into the description string. Use the repo's `#no-space-after-hash` comment style.
 - Avoid multi-sentence descriptions — they bloat the file and make the input list hard to scan.
 - Keeping `key: value` pairs out of descriptions also avoids the colon-space sequence that would otherwise force the whole scalar to be quoted.

--- a/.gitignore
+++ b/.gitignore
@@ -426,3 +426,6 @@ FodyWeavers.xsd
 *.msix
 *.msm
 *.msp
+
+# HVE / Copilot runtime artefacts
+.copilot-tracking/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,22 +1,57 @@
+# Shared pre-commit configuration, kept as close to identical as possible across every
+# f2calv repository - only the repo-specific paths in the top-level `exclude` differ.
+#
+# Linting is run manually; the `lint` job in CI is the authoritative gate:
+#   pre-commit run --all-files
+#   pre-commit autoupdate           #refresh the rev: pins below
+#
+# Note: the per-commit git hook is deliberately NOT installed - its cost is fixed
+# interpreter start-up per hook, so a one-file commit pays the same price as a full run.
+# `pre-commit install` therefore installs a cheaper once-per-push hook instead.
+default_install_hook_types: [pre-push]
+
+# Excluded from EVERY hook. Prefer a per-hook `exclude:` when only one hook is noisy, so
+# the file keeps the rest of its checks.
 exclude: |
   (?x)^(
-    .devcontainer/devcontainer.json
+    \.editorconfig|
+    \.devcontainer/devcontainer\.json
   )$
+
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v6.0.0
   hooks:
+  #structural validation
   - id: check-xml
   - id: check-yaml
     args: [--allow-multiple-documents]
-  - id: check-json
+  - id: check-toml
+  - id: check-merge-conflict
+  - id: check-case-conflict
   - id: check-added-large-files
-    args: [--maxkb=50]
+    args: [--maxkb=150]
+  #whitespace hygiene
+  #Note: line endings are owned by .gitattributes (* text=auto eol=lf), which normalises at
+  #the git layer. A mixed-line-ending hook only rewrites worktree bytes git already treats as
+  #identical, so it produces churn on Windows without protecting anything.
   - id: end-of-file-fixer
+    #Note: Visual Studio and VS Code drop the trailing newline when they format JSON on
+    #save, so these files churn on every edit and break CI. Their content is still
+    #validated by check-json5 below - only the newline check is waived.
+    exclude: |
+      (?x)(
+        appsettings.*\.json$|
+        launchSettings\.json$|
+        ^\.vscode/.*\.json$
+      )
   - id: trailing-whitespace
-  - id: double-quote-string-fixer
+- repo: https://gitlab.com/bmares/check-json5
+  rev: v1.0.1
+  hooks:
+  - id: check-json5
 - repo: https://github.com/igorshubovych/markdownlint-cli
-  rev: v0.45.0
+  rev: v0.49.1
   hooks:
   - id: markdownlint
     args: ["--disable", "MD013", "--disable", "MD034", "--"]


### PR DESCRIPTION
## Summary

- Add devcontainer and `.pre-commit-config.yaml`
- Fix outstanding pre-commit lint findings
- Pin `docker-outside-of-docker` `moby=false` (Debian trixie fix)
- Sync shared `.github/instructions/` conventions: bash scripting conventions, GitHub Actions script-extraction requirement, terse input descriptions
- `.gitignore` update